### PR TITLE
Replace demo page with medical scheduler interface

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -500,7 +500,7 @@ const Index = () => {
                       style={{
                         backgroundColor: "#ff7f00",
                       >
-                        boxShadow: "0 2px 0 rgba(255, 127, 0, 0.1)",
+                        Exam
                       }}
                     >
               <Text style={{ color: "white", fontSize: "12px" }}>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -23,7 +23,7 @@ import {
 } from "@ant-design/icons";
 
 const { Sider, Content, Header } = Layout;
-const { Title, Text } = Typography;
+const { Text } = Typography;
 const { Option } = Select;
 const { TextArea } = Input;
 
@@ -73,7 +73,12 @@ const Index = () => {
       </Header>
 
       <Layout>
-        <Sider width={240} breakpoint="lg" collapsedWidth="0" style={{ backgroundColor: "#3a3a3a" }}>
+        <Sider
+          width={240}
+          breakpoint="lg"
+          collapsedWidth="0"
+          style={{ backgroundColor: "#3a3a3a" }}
+        >
           <div style={{ padding: "16px", color: "white" }}>
             <div style={{ marginBottom: "16px" }}>
               <Text style={{ color: "white", fontSize: "14px" }}>Patients</Text>
@@ -151,7 +156,7 @@ const Index = () => {
                     }
                   >
                     <Row gutter={8}>
-                      <Col xs={24} sm={24} md={24} lg={8} xl={8}>
+                      <Col xs={8} sm={8} md={8} lg={8} xl={8}>
                         <Input placeholder="MM/yyyy" />
                       </Col>
                       <Col xs={16} sm={16} md={16} lg={16} xl={16}>
@@ -446,72 +451,71 @@ const Index = () => {
                   Mandatory Information
                 </Text>
               </div>
-                <Row
-                  justify="space-between"
-                  align="middle"
-                  style={{ width: "100%" }}
-                >
-                  <div style={{ marginBottom: "16px" }}>
-                    <Space size="middle" wrap>
+              <Row
+                justify="space-between"
+                align="middle"
+                style={{ width: "100%" }}
+              >
+                <Col xs={24} sm={24} md={12} lg={12} xl={12}>
+                  <Space size="middle" wrap>
+                    <Button
+                      icon={<SaveOutlined />}
+                      style={{
+                        backgroundColor: "#f5f5f5",
+                        borderColor: "#d9d9d9",
+                        color: "#000",
+                      }}
+                    >
+                      Save
+                    </Button>
+                    <Button
+                      style={{
+                        backgroundColor: "#f5f5f5",
+                        borderColor: "#d9d9d9",
+                        color: "#000",
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                    <Button icon={<DeleteOutlined />}>Delete</Button>
+                  </Space>
+                </Col>
+                <Col xs={24} sm={24} md={12} lg={12} xl={12}>
+                  <Space size="middle" wrap>
+                    <Button.Group>
                       <Button
-                        icon={<SaveOutlined />}
                         style={{
-                          backgroundColor: "#f5f5f5",
-                          borderColor: "#d9d9d9",
-                          color: "#000",
+                          backgroundColor: "#595959",
+                          borderColor: "#595959",
+                          color: "white",
                         }}
                       >
-                        Save
+                        Local Data
                       </Button>
                       <Button
                         style={{
-                          backgroundColor: "#f5f5f5",
-                          borderColor: "#d9d9d9",
-                          color: "#000",
+                          backgroundColor: "#595959",
+                          borderColor: "#595959",
+                          color: "white",
                         }}
                       >
-                        Cancel
+                        Prior Studies
                       </Button>
-                      <Button icon={<DeleteOutlined />}>Delete</Button>
-                    </Space>
-                  </Col>
-                  <div style={{ marginBottom: "16px" }}>
-                    <Space size="middle" wrap>
-                      <Button.Group style={{ margin: "0 1rem 0 1rem", justifyContent: "center", alignItems: "flex-start" }}>
-                        <Button
-                          style={{
-                            backgroundColor: "#595959",
-                            borderColor: "#595959",
-                            color: "white",
-                          }}
-                        >
-                          Local Data
-                        </Button>
-                        <Button
-                          style={{
-                            backgroundColor: "#595959",
-                            borderColor: "#595959",
-                            color: "white",
-                          }}
-                        >
-                          Prior Studies
-                        </Button>
-                      </Button.Group>
-                      <Button
-                        type="primary"
-                        style={{
-                          backgroundColor: "#ff7f00",
-                          borderColor: "#ff7f00",
-                          boxShadow: "0 2px 0 rgba(255, 127, 0, 0.1)", marginLeft: "auto",
-                        }}
-                      >
-                        Exam
-                      </Button>
-                    </Space>
-                  </Col>
-                </Row>
-              </Col>
-            </Row>
+                    </Button.Group>
+                    <Button
+                      type="primary"
+                      style={{
+                        backgroundColor: "#ff7f00",
+                        borderColor: "#ff7f00",
+                        boxShadow: "0 2px 0 rgba(255, 127, 0, 0.1)",
+                      }}
+                    >
+                      Exam
+                    </Button>
+                  </Space>
+                </Col>
+              </Row>
+            </div>
             <div style={{ textAlign: "right", marginTop: "8px" }}>
               <Text style={{ color: "white", fontSize: "12px" }}>
                 6:43:11 PM
@@ -520,6 +524,7 @@ const Index = () => {
           </Card>
         </Content>
       </Layout>
+    </Layout>
   );
 };
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -498,7 +498,7 @@ const Index = () => {
                     <Button
                       type="primary"
                       style={{
-                        backgroundColor: "#ff7f00",
+                        borderColor: "#ff7f00",
                         Exam
               <Text style={{ color: "white", fontSize: "12px" }}>
                 6:43:11 PM

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,184 +1,488 @@
+import React, { useState } from "react";
 import {
-  Button,
+  Layout,
   Card,
-  Space,
-  Typography,
-  Spin,
-  Row,
-  Col,
-  Divider,
-  Tag,
-  Avatar,
-  Badge,
+  Form,
   Input,
   Select,
   DatePicker,
-  Switch,
-  Slider,
-  Rate,
-  Progress,
+  InputNumber,
+  Radio,
+  Checkbox,
+  Button,
+  Typography,
+  Divider,
+  Space,
+  Row,
+  Col,
+  Table,
+  Tag,
   Alert,
-  Tooltip,
+  Switch,
 } from "antd";
 import {
-  UserOutlined,
-  MailOutlined,
-  PhoneOutlined,
-  HomeOutlined,
-  StarOutlined,
-  HeartOutlined,
   SearchOutlined,
+  SaveOutlined,
+  DeleteOutlined,
+  UserOutlined,
+  MedicineBoxOutlined,
+  ExperimentOutlined,
 } from "@ant-design/icons";
 
-const { Title, Paragraph, Text } = Typography;
+const { Sider, Content, Header } = Layout;
+const { Title, Text } = Typography;
 const { Option } = Select;
+const { TextArea } = Input;
 
 const Index = () => {
+  const [form] = Form.useForm();
+  const [selectedPatient, setSelectedPatient] = useState("VidOps");
+
+  // Sample patient data
+  const patients = [
+    { key: "1", patient: "VidOps", procedure: "4/28/2022, 20:41" },
+  ];
+
+  const patientColumns = [
+    {
+      title: "Patient",
+      dataIndex: "patient",
+      key: "patient",
+    },
+    {
+      title: "Procedure",
+      dataIndex: "procedure",
+      key: "procedure",
+    },
+  ];
+
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        backgroundColor: "#f5f5f5",
-        padding: "24px",
-      }}
-    >
-      <div style={{ maxWidth: "1200px", margin: "0 auto" }}>
-        {/* Header Section */}
-        <Card style={{ marginBottom: "24px" }}>
-          <div style={{ textAlign: "center" }}>
-            <Avatar
-              size={64}
-              icon={<UserOutlined />}
-              style={{ marginBottom: "16px" }}
+    <Layout style={{ minHeight: "100vh", backgroundColor: "#2c2c2c" }}>
+      {/* Header */}
+      <Header
+        style={{
+          backgroundColor: "#1f1f1f",
+          padding: "0 16px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <div style={{ color: "white", fontSize: "16px", fontWeight: "bold" }}>
+          Medical Scheduler
+        </div>
+        <Space>
+          <Button icon={<SearchOutlined />} size="small">
+            Search by Name, ID, SSN, Description, Proc Code
+          </Button>
+          <Button type="primary" size="small">
+            Patient Registration
+          </Button>
+          <Button type="default" size="small">
+            Program Selection
+          </Button>
+        </Space>
+      </Header>
+
+      <Layout>
+        {/* Left Sidebar - Patient List */}
+        <Sider width={240} style={{ backgroundColor: "#3a3a3a" }}>
+          <div style={{ padding: "16px", color: "white" }}>
+            <div style={{ marginBottom: "16px" }}>
+              <Text style={{ color: "white", fontSize: "14px" }}>Patients</Text>
+              <Text
+                style={{ color: "white", fontSize: "12px", marginLeft: "8px" }}
+              >
+                Schedule - 1T Aug @8:05:37 PM
+              </Text>
+            </div>
+
+            <Table
+              dataSource={patients}
+              columns={patientColumns}
+              size="small"
+              pagination={false}
+              style={{ backgroundColor: "#4a4a4a" }}
+              rowSelection={{
+                type: "radio",
+                selectedRowKeys: ["1"],
+              }}
             />
-            <Title level={2}>
-              <Spin
-                indicator={
-                  <StarOutlined spin style={{ fontSize: 24, marginRight: 8 }} />
-                }
-              />
-              Welcome to Ant Design
-            </Title>
-            <Paragraph>
-              Your app is now powered by Ant Design - the world's second most
-              popular React UI library.
-            </Paragraph>
-            <Space>
-              <Tag color="blue">React</Tag>
-              <Tag color="volcano">TypeScript</Tag>
-              <Tag color="green">Ant Design</Tag>
-              <Tag color="orange">Vite</Tag>
-            </Space>
-          </div>
-        </Card>
 
-        {/* Component Showcase */}
-        <Row gutter={[16, 16]}>
-          {/* Form Components */}
-          <Col xs={24} md={12} lg={8}>
-            <Card title="Form Components" extra={<Badge count={5} />}>
-              <Space direction="vertical" style={{ width: "100%" }}>
-                <Input
-                  placeholder="Enter your name"
-                  prefix={<UserOutlined />}
-                />
-                <Input
-                  placeholder="Enter your email"
-                  prefix={<MailOutlined />}
-                />
-                <Select defaultValue="option1" style={{ width: "100%" }}>
-                  <Option value="option1">Option 1</Option>
-                  <Option value="option2">Option 2</Option>
-                  <Option value="option3">Option 3</Option>
-                </Select>
-                <DatePicker style={{ width: "100%" }} />
-                <div
-                  style={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "center",
-                  }}
-                >
-                  <Text>Enable notifications</Text>
-                  <Switch defaultChecked />
-                </div>
-              </Space>
-            </Card>
-          </Col>
-
-          {/* Interactive Components */}
-          <Col xs={24} md={12} lg={8}>
-            <Card
-              title="Interactive Elements"
-              extra={<HeartOutlined style={{ color: "#ff4d4f" }} />}
+            <div
+              style={{ marginTop: "16px", color: "white", fontSize: "12px" }}
             >
-              <Space direction="vertical" style={{ width: "100%" }}>
-                <div>
-                  <Text>Rating:</Text>
-                  <Rate defaultValue={4} />
+              Waiting for scan instructions.
+            </div>
+          </div>
+        </Sider>
+
+        {/* Main Content Area */}
+        <Content style={{ padding: "16px", backgroundColor: "#2c2c2c" }}>
+          <Row gutter={16}>
+            {/* VidOps Section */}
+            <Col span={8}>
+              <Card
+                title="VidOps"
+                size="small"
+                style={{ backgroundColor: "#3a3a3a", marginBottom: "16px" }}
+                headStyle={{ color: "white", backgroundColor: "#2a2a2a" }}
+                bodyStyle={{ backgroundColor: "#3a3a3a" }}
+              >
+                <Form layout="vertical" size="small">
+                  <Form.Item
+                    label={<Text style={{ color: "white" }}>Last Name</Text>}
+                  >
+                    <Input defaultValue="VidOps" />
+                  </Form.Item>
+                  <Form.Item
+                    label={<Text style={{ color: "white" }}>First Name</Text>}
+                  >
+                    <Input />
+                  </Form.Item>
+                  <Form.Item
+                    label={<Text style={{ color: "white" }}>Title</Text>}
+                  >
+                    <Input />
+                  </Form.Item>
+                  <Form.Item
+                    label={<Text style={{ color: "white" }}>Suffix</Text>}
+                  >
+                    <Input />
+                  </Form.Item>
+                  <Form.Item
+                    label={<Text style={{ color: "white" }}>Middle Name</Text>}
+                  >
+                    <Input />
+                  </Form.Item>
+                  <Form.Item
+                    label={<Text style={{ color: "white" }}>Patient ID</Text>}
+                  >
+                    <Input />
+                  </Form.Item>
+                  <Form.Item
+                    label={
+                      <Text style={{ color: "white" }}>Date of Birth</Text>
+                    }
+                  >
+                    <Row gutter={8}>
+                      <Col span={8}>
+                        <Input placeholder="MM/yyyy" />
+                      </Col>
+                      <Col span={16}>
+                        <DatePicker style={{ width: "100%" }} />
+                      </Col>
+                    </Row>
+                  </Form.Item>
+                  <Form.Item
+                    label={<Text style={{ color: "white" }}>Age</Text>}
+                  >
+                    <InputNumber style={{ width: "100%" }} />
+                  </Form.Item>
+                  <Form.Item
+                    label={<Text style={{ color: "white" }}>Sex</Text>}
+                  >
+                    <Select defaultValue="M">
+                      <Option value="M">M</Option>
+                      <Option value="F">F</Option>
+                    </Select>
+                  </Form.Item>
+                  <Form.Item
+                    label={<Text style={{ color: "white" }}>Height</Text>}
+                  >
+                    <Row gutter={8}>
+                      <Col span={12}>
+                        <InputNumber style={{ width: "100%" }} />
+                      </Col>
+                      <Col span={12}>
+                        <Select defaultValue="ft">
+                          <Option value="ft">ft</Option>
+                          <Option value="in">in</Option>
+                        </Select>
+                      </Col>
+                    </Row>
+                  </Form.Item>
+                  <Form.Item
+                    label={<Text style={{ color: "white" }}>Weight</Text>}
+                  >
+                    <Row gutter={8}>
+                      <Col span={12}>
+                        <InputNumber style={{ width: "100%" }} />
+                      </Col>
+                      <Col span={12}>
+                        <Select defaultValue="lbs">
+                          <Option value="lbs">lbs</Option>
+                          <Option value="kg">kg</Option>
+                        </Select>
+                      </Col>
+                    </Row>
+                  </Form.Item>
+                </Form>
+              </Card>
+            </Col>
+
+            {/* Medical Information */}
+            <Col span={8}>
+              <Card
+                title="Medical Information"
+                size="small"
+                style={{ backgroundColor: "#3a3a3a", marginBottom: "16px" }}
+                headStyle={{ color: "white", backgroundColor: "#2a2a2a" }}
+                bodyStyle={{ backgroundColor: "#3a3a3a" }}
+              >
+                <Form layout="vertical" size="small">
+                  <Form.Item
+                    label={
+                      <Text style={{ color: "white" }}>
+                        Admitting Diagnosis
+                      </Text>
+                    }
+                  >
+                    <TextArea rows={3} />
+                  </Form.Item>
+                  <Form.Item
+                    label={<Text style={{ color: "white" }}>Procedure</Text>}
+                  >
+                    <TextArea rows={2} />
+                  </Form.Item>
+                </Form>
+
+                <Divider style={{ borderColor: "#555", margin: "16px 0" }} />
+
+                <div style={{ marginBottom: "16px" }}>
+                  <Text style={{ color: "white", fontWeight: "bold" }}>
+                    Alerts
+                  </Text>
+                  <Card
+                    size="small"
+                    style={{ backgroundColor: "#4a4a4a", marginTop: "8px" }}
+                  >
+                    <Form.Item
+                      label={
+                        <Text style={{ color: "white" }}>Medical Alerts</Text>
+                      }
+                    >
+                      <TextArea rows={2} />
+                    </Form.Item>
+                    <Form.Item
+                      label={<Text style={{ color: "white" }}>Allergies</Text>}
+                    >
+                      <TextArea rows={2} />
+                    </Form.Item>
+                  </Card>
                 </div>
+
+                <Divider style={{ borderColor: "#555", margin: "16px 0" }} />
+
                 <div>
-                  <Text>Volume:</Text>
-                  <Slider defaultValue={30} />
+                  <Text style={{ color: "white", fontWeight: "bold" }}>
+                    Institution
+                  </Text>
+                  <Form
+                    layout="vertical"
+                    size="small"
+                    style={{ marginTop: "8px" }}
+                  >
+                    <Form.Item
+                      label={
+                        <Text style={{ color: "white" }}>Institution Name</Text>
+                      }
+                    >
+                      <Input defaultValue="UCLA Psyc" />
+                    </Form.Item>
+                    <Form.Item
+                      label={
+                        <Text style={{ color: "white" }}>
+                          Performing Physician
+                        </Text>
+                      }
+                    >
+                      <Input />
+                    </Form.Item>
+                    <Form.Item
+                      label={
+                        <Text style={{ color: "white" }}>
+                          Referring Physician
+                        </Text>
+                      }
+                    >
+                      <Input />
+                    </Form.Item>
+                    <Form.Item
+                      label={
+                        <Text style={{ color: "white" }}>
+                          Requesting Physician
+                        </Text>
+                      }
+                    >
+                      <Input />
+                    </Form.Item>
+                    <Form.Item
+                      label={<Text style={{ color: "white" }}>Operator</Text>}
+                    >
+                      <Input />
+                    </Form.Item>
+                  </Form>
                 </div>
+              </Card>
+            </Col>
+
+            {/* Examination Information & Program Selection */}
+            <Col span={8}>
+              <Card
+                title="Examination Information"
+                size="small"
+                style={{ backgroundColor: "#3a3a3a", marginBottom: "16px" }}
+                headStyle={{ color: "white", backgroundColor: "#2a2a2a" }}
+                bodyStyle={{ backgroundColor: "#3a3a3a" }}
+              >
+                <Form layout="vertical" size="small">
+                  <Form.Item
+                    label={
+                      <Text style={{ color: "white" }}>Accession Nr.</Text>
+                    }
+                  >
+                    <Input />
+                  </Form.Item>
+                  <Form.Item
+                    label={<Text style={{ color: "white" }}>Real Proc ID</Text>}
+                  >
+                    <Input />
+                  </Form.Item>
+                  <Form.Item
+                    label={
+                      <Text style={{ color: "white" }}>Study Description</Text>
+                    }
+                  >
+                    <Input defaultValue="LEE 35 channel" />
+                  </Form.Item>
+                  <Form.Item
+                    label={
+                      <Text style={{ color: "white" }}>Study Comment</Text>
+                    }
+                  >
+                    <TextArea rows={2} />
+                  </Form.Item>
+                </Form>
+              </Card>
+
+              <Card
+                title="Program Selection"
+                size="small"
+                style={{ backgroundColor: "#3a3a3a", marginBottom: "16px" }}
+                headStyle={{ color: "white", backgroundColor: "#2a2a2a" }}
+                bodyStyle={{ backgroundColor: "#3a3a3a" }}
+              >
+                <div style={{ marginBottom: "16px" }}>
+                  <Text style={{ color: "white" }}>
+                    USER - LEE - 35 channel - Any Prog...
+                  </Text>
+                  <div style={{ marginTop: "8px" }}>
+                    <Checkbox style={{ color: "white" }}>
+                      Load Program to Queue
+                    </Checkbox>
+                  </div>
+                </div>
+
+                <Divider style={{ borderColor: "#555", margin: "16px 0" }} />
+
+                <div style={{ marginBottom: "16px" }}>
+                  <Text style={{ color: "white", fontWeight: "bold" }}>
+                    RF Transmit Mode
+                  </Text>
+                  <Select
+                    defaultValue="Brain"
+                    style={{ width: "100%", marginTop: "8px" }}
+                  >
+                    <Option value="Brain">Brain</Option>
+                    <Option value="Body">Body</Option>
+                    <Option value="Head">Head</Option>
+                  </Select>
+                </div>
+
+                <div style={{ marginBottom: "16px" }}>
+                  <Text style={{ color: "white", fontWeight: "bold" }}>
+                    Body Part and Laterality
+                  </Text>
+                  <div style={{ marginTop: "8px" }}>
+                    <Row gutter={8}>
+                      <Col span={12}>
+                        <Select defaultValue="Brain" style={{ width: "100%" }}>
+                          <Option value="Brain">Brain</Option>
+                          <Option value="Head">Head</Option>
+                          <Option value="Spine">Spine</Option>
+                        </Select>
+                      </Col>
+                      <Col span={12}>
+                        <Select
+                          defaultValue="Unpaired"
+                          style={{ width: "100%" }}
+                        >
+                          <Option value="Unpaired">Unpaired</Option>
+                          <Option value="Left">Left</Option>
+                          <Option value="Right">Right</Option>
+                        </Select>
+                      </Col>
+                    </Row>
+                    <Select
+                      defaultValue="Select"
+                      style={{ width: "100%", marginTop: "8px" }}
+                    >
+                      <Option value="Select">Select</Option>
+                      <Option value="Option1">Option 1</Option>
+                      <Option value="Option2">Option 2</Option>
+                    </Select>
+                  </div>
+                </div>
+
                 <div>
-                  <Text>Progress:</Text>
-                  <Progress percent={75} status="active" />
+                  <Text style={{ color: "white", fontWeight: "bold" }}>
+                    Patient Orientation
+                  </Text>
+                  <Select
+                    defaultValue="Select"
+                    style={{ width: "100%", marginTop: "8px" }}
+                  >
+                    <Option value="Select">Select</Option>
+                    <Option value="Supine">Supine</Option>
+                    <Option value="Prone">Prone</Option>
+                  </Select>
                 </div>
+              </Card>
+            </Col>
+          </Row>
+
+          {/* Bottom Action Bar */}
+          <Card
+            style={{ backgroundColor: "#3a3a3a", marginTop: "16px" }}
+            bodyStyle={{ backgroundColor: "#3a3a3a" }}
+          >
+            <Row justify="space-between" align="middle">
+              <Col>
+                <Text style={{ color: "white" }}>
+                  Safety relevant information needs to be valid and confirmed. ★
+                  Manifestation
+                </Text>
+              </Col>
+              <Col>
                 <Space>
-                  <Button type="primary" icon={<SearchOutlined />}>
-                    Search
-                  </Button>
-                  <Tooltip title="This is a tooltip">
-                    <Button icon={<HomeOutlined />}>Home</Button>
-                  </Tooltip>
+                  <Button icon={<SaveOutlined />}>Save</Button>
+                  <Button>Cancel</Button>
+                  <Button icon={<DeleteOutlined />}>Delete</Button>
+                  <Button type="primary">Local Data</Button>
+                  <Button>Prior</Button>
                 </Space>
-              </Space>
-            </Card>
-          </Col>
-
-          {/* Display Components */}
-          <Col xs={24} md={12} lg={8}>
-            <Card title="Display Elements">
-              <Space direction="vertical" style={{ width: "100%" }}>
-                <Alert
-                  message="Success Tips"
-                  description="Detailed description and advice about successful copywriting."
-                  type="success"
-                  showIcon
-                />
-                <div>
-                  <Badge count={99} overflowCount={99}>
-                    <Avatar
-                      shape="square"
-                      size="large"
-                      icon={<PhoneOutlined />}
-                    />
-                  </Badge>
-                </div>
-                <Divider>Statistics</Divider>
-                <div style={{ textAlign: "center" }}>
-                  <Title level={3} style={{ margin: "8px 0" }}>
-                    2,048
-                  </Title>
-                  <Text type="secondary">Total Users</Text>
-                </div>
-              </Space>
-            </Card>
-          </Col>
-        </Row>
-
-        {/* Footer */}
-        <Card style={{ marginTop: "24px", textAlign: "center" }}>
-          <Paragraph>
-            <Text type="secondary">
-              Built with ❤️ using Ant Design. Explore the{" "}
-              <Text code>components</Text> to build amazing interfaces.
-            </Text>
-          </Paragraph>
-        </Card>
-      </div>
-    </div>
+              </Col>
+            </Row>
+            <div style={{ textAlign: "right", marginTop: "8px" }}>
+              <Text style={{ color: "white", fontSize: "12px" }}>
+                6:43:11 PM
+              </Text>
+            </div>
+          </Card>
+        </Content>
+      </Layout>
+    </Layout>
   );
 };
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -507,6 +507,7 @@ const Index = () => {
                   </Space>
                 </Col>
               </Row>
+            </div>
               <Text style={{ color: "white", fontSize: "12px" }}>
                 6:43:11 PM
               </Text>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -439,7 +439,7 @@ const Index = () => {
             style={{ backgroundColor: "#3a3a3a", marginTop: "16px" }}
             bodyStyle={{ backgroundColor: "#3a3a3a" }}
           >
-            <Row justify="space-between" align="middle">
+            <div>
               <Col xs={24} sm={24} md={12} lg={12} xl={12}>
                 <Text style={{ color: "white" }}>
                   Safety relevant information needs to be valid and confirmed. ★

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -443,7 +443,7 @@ const Index = () => {
               <Col>
                 <Text style={{ color: "white" }}>
                   Safety relevant information needs to be valid and confirmed. ★
-                  Manifestation
+                  Mandatory Information
                 </Text>
               </Col>
               <Col>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -503,7 +503,7 @@ const Index = () => {
                         style={{
                           backgroundColor: "#ff7f00",
                           borderColor: "#ff7f00",
-                          boxShadow: "0 2px 0 rgba(255, 127, 0, 0.1)",
+                          boxShadow: "0 2px 0 rgba(255, 127, 0, 0.1)", marginLeft: "15em",
                         }}
                       >
                         Exam

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -453,7 +453,16 @@ const Index = () => {
                   <Button icon={<DeleteOutlined />}>Delete</Button>
                   <Button type="primary">Local Data</Button>
                   <Button>Prior Studies</Button>
-                  <Button style={{ backgroundColor: "#ff7f00", borderColor: "#ff7f00", color: "white" }}>Exam</Button>
+                  <Button
+                    type="primary"
+                    style={{
+                      backgroundColor: "#ff7f00",
+                      borderColor: "#ff7f00",
+                      boxShadow: "0 2px 0 rgba(255, 127, 0, 0.1)",
+                    }}
+                  >
+                    Exam
+                  </Button>
                 </Space>
               </Col>
             </Row>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -509,7 +509,6 @@ const Index = () => {
               </Row>
             </div>
                 6:43:11 PM
-            <div style={{ textAlign: "right", marginTop: "8px" }}>
               <Text style={{ color: "white", fontSize: "12px" }}>
             </div>
           </Card>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import {
   Layout,
   Card,
@@ -7,7 +7,6 @@ import {
   Select,
   DatePicker,
   InputNumber,
-  Radio,
   Checkbox,
   Button,
   Typography,
@@ -16,17 +15,11 @@ import {
   Row,
   Col,
   Table,
-  Tag,
-  Alert,
-  Switch,
 } from "antd";
 import {
   SearchOutlined,
   SaveOutlined,
   DeleteOutlined,
-  UserOutlined,
-  MedicineBoxOutlined,
-  ExperimentOutlined,
 } from "@ant-design/icons";
 
 const { Sider, Content, Header } = Layout;
@@ -35,9 +28,6 @@ const { Option } = Select;
 const { TextArea } = Input;
 
 const Index = () => {
-  const [form] = Form.useForm();
-  const [selectedPatient, setSelectedPatient] = useState("VidOps");
-
   const patients = [
     { key: "1", patient: "VidOps", procedure: "4/28/2022, 20:41" },
   ];

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -509,6 +509,7 @@ const Index = () => {
               </Row>
             </div>
                 6:43:11 PM
+            <div style={{ textAlign: "right", marginTop: "8px" }}>
               </Text>
             </div>
           </Card>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -446,7 +446,6 @@ const Index = () => {
                   Mandatory Information
                 </Text>
               </div>
-              <div style={{ marginBottom: "16px" }}>
                 <Row
                   justify="space-between"
                   align="middle"

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -106,7 +106,7 @@ const Index = () => {
 
         <Content style={{ padding: "16px", backgroundColor: "#2c2c2c" }}>
           <Row gutter={16}>
-            <Col span={8}>
+            <Col xs={24} sm={24} md={24} lg={8} xl={8}>
               <Card
                 title="VidOps"
                 size="small"
@@ -151,7 +151,7 @@ const Index = () => {
                     }
                   >
                     <Row gutter={8}>
-                      <Col span={8}>
+                      <Col xs={24} sm={24} md={24} lg={8} xl={8}>
                         <Input placeholder="MM/yyyy" />
                       </Col>
                       <Col span={16}>
@@ -206,7 +206,7 @@ const Index = () => {
               </Card>
             </Col>
 
-            <Col span={8}>
+            <Col xs={24} sm={24} md={24} lg={8} xl={8}>
               <Card
                 title="Medical Information"
                 size="small"
@@ -311,7 +311,7 @@ const Index = () => {
               </Card>
             </Col>
 
-            <Col span={8}>
+            <Col xs={24} sm={24} md={24} lg={8} xl={8}>
               <Card
                 title="Examination Information"
                 size="small"

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -318,13 +318,6 @@ const Index = () => {
 
             <Col xs={24} sm={24} md={24} lg={8} xl={8}>
               <Card
-                title="Examination Information"
-                size="small"
-                style={{ backgroundColor: "#3a3a3a", marginBottom: "16px" }}
-                headStyle={{ color: "white", backgroundColor: "#2a2a2a" }}
-                bodyStyle={{ backgroundColor: "#3a3a3a" }}
-              >
-                <Form layout="vertical" size="small">
                   <Form.Item
                     label={
                       <Text style={{ color: "white" }}>Accession Nr.</Text>
@@ -510,13 +503,6 @@ const Index = () => {
                         boxShadow: "0 2px 0 rgba(255, 127, 0, 0.1)",
                       }}
                     >
-                      Exam
-                    </Button>
-                  </Space>
-                </Col>
-              </Row>
-            </div>
-            <div style={{ textAlign: "right", marginTop: "8px" }}>
               <Text style={{ color: "white", fontSize: "12px" }}>
                 6:43:11 PM
               </Text>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -502,6 +502,7 @@ const Index = () => {
                         boxShadow: "0 2px 0 rgba(255, 127, 0, 0.1)",
                       }}
                     >
+                      Exam
               <Text style={{ color: "white", fontSize: "12px" }}>
                 6:43:11 PM
               </Text>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -505,6 +505,7 @@ const Index = () => {
                       Exam
                     </Button>
                   </Space>
+                </Col>
               <Text style={{ color: "white", fontSize: "12px" }}>
                 6:43:11 PM
               </Text>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -499,7 +499,7 @@ const Index = () => {
                       type="primary"
                       style={{
                         backgroundColor: "#ff7f00",
-                      >
+                        Exam
               <Text style={{ color: "white", fontSize: "12px" }}>
                 6:43:11 PM
               </Text>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -154,7 +154,7 @@ const Index = () => {
                       <Col xs={24} sm={24} md={24} lg={8} xl={8}>
                         <Input placeholder="MM/yyyy" />
                       </Col>
-                      <Col span={16}>
+                      <Col xs={16} sm={16} md={16} lg={16} xl={16}>
                         <DatePicker style={{ width: "100%" }} />
                       </Col>
                     </Row>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -447,12 +447,13 @@ const Index = () => {
                 </Text>
               </Col>
               <Col>
-                <Space>
+                <Space size="middle">
                   <Button icon={<SaveOutlined />}>Save</Button>
                   <Button>Cancel</Button>
                   <Button icon={<DeleteOutlined />}>Delete</Button>
                   <Button type="primary">Local Data</Button>
-                  <Button>Prior</Button>
+                  <Button>Prior Data</Button>
+                  <Button>Prior Data</Button>
                 </Space>
               </Col>
             </Row>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -176,10 +176,10 @@ const Index = () => {
                     label={<Text style={{ color: "white" }}>Height</Text>}
                   >
                     <Row gutter={8}>
-                      <Col span={12}>
+                      <Col xs={12} sm={12} md={12} lg={12} xl={12}>
                         <InputNumber style={{ width: "100%" }} />
                       </Col>
-                      <Col span={12}>
+                      <Col xs={12} sm={12} md={12} lg={12} xl={12}>
                         <Select defaultValue="ft">
                           <Option value="ft">ft</Option>
                           <Option value="in">in</Option>
@@ -191,10 +191,10 @@ const Index = () => {
                     label={<Text style={{ color: "white" }}>Weight</Text>}
                   >
                     <Row gutter={8}>
-                      <Col span={12}>
+                      <Col xs={12} sm={12} md={12} lg={12} xl={12}>
                         <InputNumber style={{ width: "100%" }} />
                       </Col>
-                      <Col span={12}>
+                      <Col xs={12} sm={12} md={12} lg={12} xl={12}>
                         <Select defaultValue="lbs">
                           <Option value="lbs">lbs</Option>
                           <Option value="kg">kg</Option>
@@ -389,14 +389,14 @@ const Index = () => {
                   </Text>
                   <div style={{ marginTop: "8px" }}>
                     <Row gutter={8}>
-                      <Col span={12}>
+                      <Col xs={12} sm={12} md={12} lg={12} xl={12}>
                         <Select defaultValue="Brain" style={{ width: "100%" }}>
                           <Option value="Brain">Brain</Option>
                           <Option value="Head">Head</Option>
                           <Option value="Spine">Spine</Option>
                         </Select>
                       </Col>
-                      <Col span={12}>
+                      <Col xs={12} sm={12} md={12} lg={12} xl={12}>
                         <Select
                           defaultValue="Unpaired"
                           style={{ width: "100%" }}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -453,7 +453,7 @@ const Index = () => {
                   <Button icon={<DeleteOutlined />}>Delete</Button>
                   <Button type="primary">Local Data</Button>
                   <Button>Prior Studies</Button>
-                  <Button>Exam</Button>
+                  <Button style={{ backgroundColor: "#ff7f00", borderColor: "#ff7f00", color: "white" }}>Exam</Button>
                 </Space>
               </Col>
             </Row>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -38,7 +38,6 @@ const Index = () => {
   const [form] = Form.useForm();
   const [selectedPatient, setSelectedPatient] = useState("VidOps");
 
-  // Sample patient data
   const patients = [
     { key: "1", patient: "VidOps", procedure: "4/28/2022, 20:41" },
   ];
@@ -58,7 +57,6 @@ const Index = () => {
 
   return (
     <Layout style={{ minHeight: "100vh", backgroundColor: "#2c2c2c" }}>
-      {/* Header */}
       <Header
         style={{
           backgroundColor: "#1f1f1f",
@@ -85,7 +83,6 @@ const Index = () => {
       </Header>
 
       <Layout>
-        {/* Left Sidebar - Patient List */}
         <Sider width={240} style={{ backgroundColor: "#3a3a3a" }}>
           <div style={{ padding: "16px", color: "white" }}>
             <div style={{ marginBottom: "16px" }}>
@@ -117,10 +114,8 @@ const Index = () => {
           </div>
         </Sider>
 
-        {/* Main Content Area */}
         <Content style={{ padding: "16px", backgroundColor: "#2c2c2c" }}>
           <Row gutter={16}>
-            {/* VidOps Section */}
             <Col span={8}>
               <Card
                 title="VidOps"
@@ -221,7 +216,6 @@ const Index = () => {
               </Card>
             </Col>
 
-            {/* Medical Information */}
             <Col span={8}>
               <Card
                 title="Medical Information"
@@ -327,7 +321,6 @@ const Index = () => {
               </Card>
             </Col>
 
-            {/* Examination Information & Program Selection */}
             <Col span={8}>
               <Card
                 title="Examination Information"
@@ -452,7 +445,6 @@ const Index = () => {
             </Col>
           </Row>
 
-          {/* Bottom Action Bar */}
           <Card
             style={{ backgroundColor: "#3a3a3a", marginTop: "16px" }}
             bodyStyle={{ backgroundColor: "#3a3a3a" }}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -445,7 +445,7 @@ const Index = () => {
                   Safety relevant information needs to be valid and confirmed. ★
                   Mandatory Information
                 </Text>
-              </Col>
+              </div>
               <div style={{ marginBottom: "16px" }}>
                 <Row
                   justify="space-between"

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -508,7 +508,6 @@ const Index = () => {
                 </Col>
               </Row>
             </div>
-              <Text style={{ color: "white", fontSize: "12px" }}>
                 6:43:11 PM
               </Text>
             </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -318,6 +318,13 @@ const Index = () => {
 
             <Col xs={24} sm={24} md={24} lg={8} xl={8}>
               <Card
+                title="Examination Information"
+                size="small"
+                style={{ backgroundColor: "#3a3a3a", marginBottom: "16px" }}
+                headStyle={{ color: "white", backgroundColor: "#2a2a2a" }}
+                bodyStyle={{ backgroundColor: "#3a3a3a" }}
+              >
+                <Form layout="vertical" size="small">
                   <Form.Item
                     label={
                       <Text style={{ color: "white" }}>Accession Nr.</Text>
@@ -471,47 +478,53 @@ const Index = () => {
                       Cancel
                     </Button>
                     <Button icon={<DeleteOutlined />}>Delete</Button>
-                  </Space>
-                </Col>
-                <Col xs={18} sm={18} md={18} lg={18} xl={18}>
-                  <Space size="middle" wrap>
-                    
-                      <Button
-                        style={{
-                          backgroundColor: "#595959",
-                          borderColor: "#595959",
-                          color: "white",
-                        }}
-                      >
-                        Local Data
-                      </Button>
-                      <Button
-                        style={{
-                          backgroundColor: "#595959",
-                          borderColor: "#595959",
-                          color: "white",
-                        }}
-                      >
-                        Prior Studies
-                      </Button>
-                    
                     <Button
-                      type="primary"
                       style={{
-                        borderColor: "#ff7f00",
-                        boxShadow: "0 2px 0 rgba(255, 127, 0, 0.1)",
+                        backgroundColor: "#595959",
+                        borderColor: "#595959",
+                        color: "white",
                       }}
                     >
-                      Exam
+                      Local Data
+                    </Button>
+                    <Button
+                      style={{
+                        backgroundColor: "#595959",
+                        borderColor: "#595959",
+                        color: "white",
+                      }}
+                    >
+                      Prior Studies
                     </Button>
                   </Space>
                 </Col>
+                <Col
+                  xs={6}
+                  sm={6}
+                  md={6}
+                  lg={6}
+                  xl={6}
+                  style={{ display: "flex", justifyContent: "flex-end" }}
+                >
+                  <Button
+                    type="primary"
+                    style={{
+                      backgroundColor: "#ff7f00",
+                      borderColor: "#ff7f00",
+                      boxShadow: "0 2px 0 rgba(255, 127, 0, 0.1)",
+                    }}
+                  >
+                    Exam
+                  </Button>
+                </Col>
               </Row>
             </div>
-                6:43:11 PM
+            <div style={{ textAlign: "right", marginTop: "8px" }}>
               <Text style={{ color: "white", fontSize: "12px" }}>
                 6:43:11 PM
               </Text>
+            </div>
+          </Card>
         </Content>
       </Layout>
     </Layout>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -499,7 +499,7 @@ const Index = () => {
                       type="primary"
                       style={{
                         borderColor: "#ff7f00",
-                        Exam
+                        boxShadow: "0 2px 0 rgba(255, 127, 0, 0.1)",
               <Text style={{ color: "white", fontSize: "12px" }}>
                 6:43:11 PM
               </Text>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -452,8 +452,8 @@ const Index = () => {
                   <Button>Cancel</Button>
                   <Button icon={<DeleteOutlined />}>Delete</Button>
                   <Button type="primary">Local Data</Button>
-                  <Button>Prior Data</Button>
-                  <Button>Prior Data</Button>
+                  <Button>Prior Studies</Button>
+                  <Button>Exam</Button>
                 </Space>
               </Col>
             </Row>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -503,7 +503,7 @@ const Index = () => {
                         style={{
                           backgroundColor: "#ff7f00",
                           borderColor: "#ff7f00",
-                          boxShadow: "0 2px 0 rgba(255, 127, 0, 0.1)", marginLeft: "15em",
+                          boxShadow: "0 2px 0 rgba(255, 127, 0, 0.1)", marginLeft: "auto",
                         }}
                       >
                         Exam

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -504,6 +504,7 @@ const Index = () => {
                     >
                       Exam
                     </Button>
+                  </Space>
               <Text style={{ color: "white", fontSize: "12px" }}>
                 6:43:11 PM
               </Text>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -506,6 +506,7 @@ const Index = () => {
                     </Button>
                   </Space>
                 </Col>
+              </Row>
               <Text style={{ color: "white", fontSize: "12px" }}>
                 6:43:11 PM
               </Text>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -510,7 +510,7 @@ const Index = () => {
             </div>
                 6:43:11 PM
               <Text style={{ color: "white", fontSize: "12px" }}>
-            </div>
+                6:43:11 PM
           </Card>
         </Content>
       </Layout>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -499,7 +499,7 @@ const Index = () => {
                       type="primary"
                       style={{
                         backgroundColor: "#ff7f00",
-                        borderColor: "#ff7f00",
+                      >
                         boxShadow: "0 2px 0 rgba(255, 127, 0, 0.1)",
                       }}
                     >

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -456,7 +456,7 @@ const Index = () => {
                 align="middle"
                 style={{ width: "100%" }}
               >
-                <Col xs={24} sm={24} md={12} lg={12} xl={12}>
+                <Col xs={18} sm={18} md={18} lg={18} xl={18}>
                   <Space size="middle" wrap>
                     <Button
                       icon={<SaveOutlined />}
@@ -480,7 +480,7 @@ const Index = () => {
                     <Button icon={<DeleteOutlined />}>Delete</Button>
                   </Space>
                 </Col>
-                <Col xs={24} sm={24} md={12} lg={12} xl={12}>
+                <Col xs={18} sm={18} md={18} lg={18} xl={18}>
                   <Space size="middle" wrap>
                     
                       <Button

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -503,6 +503,7 @@ const Index = () => {
                       }}
                     >
                       Exam
+                    </Button>
               <Text style={{ color: "white", fontSize: "12px" }}>
                 6:43:11 PM
               </Text>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -511,7 +511,7 @@ const Index = () => {
                 6:43:11 PM
               <Text style={{ color: "white", fontSize: "12px" }}>
                 6:43:11 PM
-          </Card>
+              </Text>
         </Content>
       </Layout>
     </Layout>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -440,19 +440,19 @@ const Index = () => {
             bodyStyle={{ backgroundColor: "#3a3a3a" }}
           >
             <div>
-              <Col xs={24} sm={24} md={12} lg={12} xl={12}>
+              <div style={{ marginBottom: "16px" }}>
                 <Text style={{ color: "white" }}>
                   Safety relevant information needs to be valid and confirmed. ★
                   Mandatory Information
                 </Text>
               </Col>
-              <Col xs={24} sm={24} md={12} lg={12} xl={12}>
+              <div style={{ marginBottom: "16px" }}>
                 <Row
                   justify="space-between"
                   align="middle"
                   style={{ width: "100%" }}
                 >
-                  <Col xs={24} sm={24} md={12} lg={12} xl={12}>
+                  <div style={{ marginBottom: "16px" }}>
                     <Space size="middle" wrap>
                       <Button
                         icon={<SaveOutlined />}
@@ -476,7 +476,7 @@ const Index = () => {
                       <Button icon={<DeleteOutlined />}>Delete</Button>
                     </Space>
                   </Col>
-                  <Col xs={24} sm={24} md={12} lg={12} xl={12}>
+                  <div style={{ marginBottom: "16px" }}>
                     <Space size="middle" wrap>
                       <Button.Group style={{ margin: "0 1rem 0 1rem", justifyContent: "center", alignItems: "flex-start" }}>
                         <Button

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -510,6 +510,7 @@ const Index = () => {
             </div>
                 6:43:11 PM
             <div style={{ textAlign: "right", marginTop: "8px" }}>
+              <Text style={{ color: "white", fontSize: "12px" }}>
               </Text>
             </div>
           </Card>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -500,6 +500,7 @@ const Index = () => {
                       style={{
                         borderColor: "#ff7f00",
                         boxShadow: "0 2px 0 rgba(255, 127, 0, 0.1)",
+                      }}
               <Text style={{ color: "white", fontSize: "12px" }}>
                 6:43:11 PM
               </Text>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -501,7 +501,7 @@ const Index = () => {
                       >
                         Prior Studies
                       </Button>
-                    </Button.Group>
+                    
                     <Button
                       type="primary"
                       style={{

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -440,19 +440,19 @@ const Index = () => {
             bodyStyle={{ backgroundColor: "#3a3a3a" }}
           >
             <Row justify="space-between" align="middle">
-              <Col>
+              <Col xs={24} sm={24} md={12} lg={12} xl={12}>
                 <Text style={{ color: "white" }}>
                   Safety relevant information needs to be valid and confirmed. ★
                   Mandatory Information
                 </Text>
               </Col>
-              <Col>
+              <Col xs={24} sm={24} md={12} lg={12} xl={12}>
                 <Row
                   justify="space-between"
                   align="middle"
                   style={{ width: "100%" }}
                 >
-                  <Col>
+                  <Col xs={24} sm={24} md={12} lg={12} xl={12}>
                     <Space size="middle">
                       <Button
                         icon={<SaveOutlined />}
@@ -476,7 +476,7 @@ const Index = () => {
                       <Button icon={<DeleteOutlined />}>Delete</Button>
                     </Space>
                   </Col>
-                  <Col>
+                  <Col xs={24} sm={24} md={12} lg={12} xl={12}>
                     <Space size="middle">
                       <Button.Group style={{ margin: "0 1.5em 0 2em", justifyContent: "center", alignItems: "flex-start" }}>
                         <Button

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -105,7 +105,7 @@ const Index = () => {
         </Sider>
 
         <Content style={{ padding: "16px", backgroundColor: "#2c2c2c" }}>
-          <Row gutter={16}>
+          <Row gutter={[16, 16]}>
             <Col xs={24} sm={24} md={24} lg={8} xl={8}>
               <Card
                 title="VidOps"

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -478,7 +478,7 @@ const Index = () => {
                   </Col>
                   <Col>
                     <Space size="middle">
-                      <Button.Group>
+                      <Button.Group style={{ margin: "0 1.5em 0 2em", justifyContent: "center", alignItems: "flex-start" }}>
                         <Button
                           style={{
                             backgroundColor: "#595959",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -447,23 +447,70 @@ const Index = () => {
                 </Text>
               </Col>
               <Col>
-                <Space size="middle">
-                  <Button icon={<SaveOutlined />}>Save</Button>
-                  <Button>Cancel</Button>
-                  <Button icon={<DeleteOutlined />}>Delete</Button>
-                  <Button type="primary">Local Data</Button>
-                  <Button>Prior Studies</Button>
-                  <Button
-                    type="primary"
-                    style={{
-                      backgroundColor: "#ff7f00",
-                      borderColor: "#ff7f00",
-                      boxShadow: "0 2px 0 rgba(255, 127, 0, 0.1)",
-                    }}
-                  >
-                    Exam
-                  </Button>
-                </Space>
+                <Row
+                  justify="space-between"
+                  align="middle"
+                  style={{ width: "100%" }}
+                >
+                  <Col>
+                    <Space size="middle">
+                      <Button
+                        icon={<SaveOutlined />}
+                        style={{
+                          backgroundColor: "#f5f5f5",
+                          borderColor: "#d9d9d9",
+                          color: "#000",
+                        }}
+                      >
+                        Save
+                      </Button>
+                      <Button
+                        style={{
+                          backgroundColor: "#f5f5f5",
+                          borderColor: "#d9d9d9",
+                          color: "#000",
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                      <Button icon={<DeleteOutlined />}>Delete</Button>
+                    </Space>
+                  </Col>
+                  <Col>
+                    <Space size="middle">
+                      <Button.Group>
+                        <Button
+                          style={{
+                            backgroundColor: "#595959",
+                            borderColor: "#595959",
+                            color: "white",
+                          }}
+                        >
+                          Local Data
+                        </Button>
+                        <Button
+                          style={{
+                            backgroundColor: "#595959",
+                            borderColor: "#595959",
+                            color: "white",
+                          }}
+                        >
+                          Prior Studies
+                        </Button>
+                      </Button.Group>
+                      <Button
+                        type="primary"
+                        style={{
+                          backgroundColor: "#ff7f00",
+                          borderColor: "#ff7f00",
+                          boxShadow: "0 2px 0 rgba(255, 127, 0, 0.1)",
+                        }}
+                      >
+                        Exam
+                      </Button>
+                    </Space>
+                  </Col>
+                </Row>
               </Col>
             </Row>
             <div style={{ textAlign: "right", marginTop: "8px" }}>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -500,9 +500,6 @@ const Index = () => {
                       style={{
                         backgroundColor: "#ff7f00",
                       >
-                        Exam
-                      }}
-                    >
               <Text style={{ color: "white", fontSize: "12px" }}>
                 6:43:11 PM
               </Text>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -73,7 +73,7 @@ const Index = () => {
       </Header>
 
       <Layout>
-        <Sider width={240} style={{ backgroundColor: "#3a3a3a" }}>
+        <Sider width={240} breakpoint="lg" collapsedWidth="0" style={{ backgroundColor: "#3a3a3a" }}>
           <div style={{ padding: "16px", color: "white" }}>
             <div style={{ marginBottom: "16px" }}>
               <Text style={{ color: "white", fontSize: "14px" }}>Patients</Text>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -453,7 +453,7 @@ const Index = () => {
                   style={{ width: "100%" }}
                 >
                   <Col xs={24} sm={24} md={12} lg={12} xl={12}>
-                    <Space size="middle">
+                    <Space size="middle" wrap>
                       <Button
                         icon={<SaveOutlined />}
                         style={{
@@ -477,7 +477,7 @@ const Index = () => {
                     </Space>
                   </Col>
                   <Col xs={24} sm={24} md={12} lg={12} xl={12}>
-                    <Space size="middle">
+                    <Space size="middle" wrap>
                       <Button.Group style={{ margin: "0 1.5em 0 2em", justifyContent: "center", alignItems: "flex-start" }}>
                         <Button
                           style={{

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -511,7 +511,6 @@ const Index = () => {
                 6:43:11 PM
             <div style={{ textAlign: "right", marginTop: "8px" }}>
               <Text style={{ color: "white", fontSize: "12px" }}>
-              </Text>
             </div>
           </Card>
         </Content>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -478,7 +478,7 @@ const Index = () => {
                   </Col>
                   <Col xs={24} sm={24} md={12} lg={12} xl={12}>
                     <Space size="middle" wrap>
-                      <Button.Group style={{ margin: "0 1.5em 0 2em", justifyContent: "center", alignItems: "flex-start" }}>
+                      <Button.Group style={{ margin: "0 1rem 0 1rem", justifyContent: "center", alignItems: "flex-start" }}>
                         <Button
                           style={{
                             backgroundColor: "#595959",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -482,7 +482,7 @@ const Index = () => {
                 </Col>
                 <Col xs={24} sm={24} md={12} lg={12} xl={12}>
                   <Space size="middle" wrap>
-                    <Button.Group>
+                    
                       <Button
                         style={{
                           backgroundColor: "#595959",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -501,6 +501,7 @@ const Index = () => {
                         borderColor: "#ff7f00",
                         boxShadow: "0 2px 0 rgba(255, 127, 0, 0.1)",
                       }}
+                    >
               <Text style={{ color: "white", fontSize: "12px" }}>
                 6:43:11 PM
               </Text>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -520,7 +520,6 @@ const Index = () => {
           </Card>
         </Content>
       </Layout>
-    </Layout>
   );
 };
 


### PR DESCRIPTION
Replace the existing Ant Design demo page with a complete medical scheduler interface.

Changes include:
- Remove demo components (buttons, cards, alerts, progress bars, etc.)
- Add Layout component with Header, Sider, and Content sections
- Implement dark theme styling (#2c2c2c background, #3a3a3a cards)
- Add patient information form with fields for name, ID, DOB, age, sex, height, weight
- Add study details form with accession number, procedure ID, description, and comments
- Add program selection section with RF transmit mode, body part selection, and patient orientation
- Include patient table in sidebar with radio selection
- Add action buttons (Save, Cancel, Delete, Local Data, Prior Studies, Exam)
- Update imports to include Layout, Form, Table, and other required components
- Remove unused demo-related imports and icons

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d956003b5b2944e68db54df8dc558780/mystic-realm)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d956003b5b2944e68db54df8dc558780</projectId>-->
<!--<branchName>mystic-realm</branchName>-->